### PR TITLE
Run on own PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,12 @@
+name: Validate that PR contains release notes
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate_release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release notes
+        uses: wandb/auto-release-notes@main


### PR DESCRIPTION
## Release Notes

Below, please enter user-facing release notes as one or more bullet points. If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Run auto-release-notes on its own PRs.
------------- END RELEASE NOTES --------------------
